### PR TITLE
Fix UrbanDict cog Installation

### DIFF
--- a/urbandict/__init__.py
+++ b/urbandict/__init__.py
@@ -1,9 +1,5 @@
 from .urbandict import urbandict
 
-__red_end_user_data_statement__ = (
-    "This cog doesn't store information about users, but stores user generated information that is likely to contain a user's name."
-)
-
 
 async def setup(bot):
     await bot.add_cog(urbandict(bot))

--- a/urbandict/info.json
+++ b/urbandict/info.json
@@ -1,5 +1,24 @@
 {
+  "name": "UrbanDict",
+  "author": [
+    "owldyn"
+  ],
+  "short": "Urban Dictionary Lookup",
+  "description": "Lookup definitions from Urban Dictionary directly within your Discord server.",
+  "install_msg": "Thanks for installing!",
   "requirements": [
     "requests"
-  ]
+  ],
+  "tags": [
+    "dictionary",
+    "urban",
+    "lookup"
+  ],
+  "min_bot_version": "3.5.0",
+  "min_python_version": [
+    3,
+    11,
+    13
+  ],
+  "end_user_data_statement": "This cog does not persistently store data or metadata about users."
 }

--- a/urbandict/info.json
+++ b/urbandict/info.json
@@ -1,0 +1,5 @@
+{
+  "requirements": [
+    "requests"
+  ]
+}

--- a/urbandict/info.json
+++ b/urbandict/info.json
@@ -5,7 +5,7 @@
   ],
   "short": "Urban Dictionary Lookup",
   "description": "Lookup definitions from Urban Dictionary directly within your Discord server.",
-  "install_msg": "Thanks for installing!",
+  "install_msg": "Thanks for installing! You can use this cog by using the `[p]defineu <term>` command to look up definitions.",
   "requirements": [
     "requests"
   ],


### PR DESCRIPTION
This pull request adds a new `info.json` file to the `urbandict` directory, specifying the package requirements.

<img width="822" height="106" alt="image" src="https://github.com/user-attachments/assets/8eaaa49f-ba82-4c68-b16b-29998df82ce9" />

<img width="383" height="341" alt="image" src="https://github.com/user-attachments/assets/405d8bc8-b5c0-44b0-89ec-40ac88b13303" />

Dependency specification:

* [`urbandict/info.json`](diffhunk://#diff-839d3fb49186a01fa880babf0ee54175c8cc3b7be0d4d40c437af283962259cbR1-R5): Added a requirements list with the `requests` package.

Resolves issues when loading the UrbanDict cog for the first time.
```python

[00:50:13] ERROR    [red] Package loading failed
Traceback (most recent call last):
  File "/workspaces/bot/.venv/lib/python3.13/site-packages/redbot/core/core_commands.py", line 189, in _load
    await bot.load_extension(spec)
  File "/workspaces/bot/.venv/lib/python3.13/site-packages/redbot/core/bot.py", line 1708, in load_extension
    lib = spec.loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 677, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 1204, in load_module
  File "<frozen importlib._bootstrap_external>", line 1028, in load_module
  File "<frozen importlib._bootstrap>", line 537, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 966, in _load
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/workspaces/bot/cogs/CogManager/cogs/urbandict/__init__.py", line 1, in <module>
    from .urbandict import urbandict
  File "/workspaces/bot/cogs/CogManager/cogs/urbandict/urbandict.py", line 2, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```